### PR TITLE
add uninstall for remove stream if reinstall after

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 **Note:** Alpha software. Pull Requests are welcome
 
-**Note:** Only one tcp/udp port per app is supported
-
 Dokku NGINX Stream gives the ability to open up tcp/udp ports
 to the outside world. This can be usefull when your application
 speaks more than http.

--- a/uninstall
+++ b/uninstall
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
+
+plugin-uninstall () {
+    local NGINX_CONF="/etc/nginx/nginx.conf"
+    sed -ri '/stream /,/.*\}/d' $NGINX_CONF
+    }
+plugin-uninstall "$@"

--- a/uninstall
+++ b/uninstall
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
-
 set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
 
-plugin-uninstall () {
-    local NGINX_CONF="/etc/nginx/nginx.conf"
-    sed -ri '/stream /,/.*\}/d' $NGINX_CONF
-    }
+plugin-uninstall() {
+  local NGINX_CONF="/etc/nginx/nginx.conf"
+
+sed -ri '/stream /,/.*\}/d' "$NGINX_CONF"
+}
+
 plugin-uninstall "$@"


### PR DESCRIPTION
Hello
- I added a trigger for the uninstallation, if we reinstall the plugin it recreates a 2nd line with stream that causes an error in nginx

 - Removed the note about the ports, it works fine even with multiple ports