### PR TITLE
fix duplicate stream blocks on install hook

### DIFF
--- a/install
+++ b/install
@@ -9,11 +9,13 @@ plugin-install () {
         > "$NGINX_STREAM_SUDOERS_FILE"
     local NGINX_CONF="/etc/nginx/nginx.conf"
     mkdir -p "/etc/nginx/app-stream"
-    cat >> $NGINX_CONF << EOF
+    if ! grep -q "include /etc/nginx/app-stream/\*.conf" "$NGINX_CONF"; then
+        cat >> $NGINX_CONF << EOF
 stream {
     include /etc/nginx/app-stream/*.conf;
 }
 EOF
+    fi
 }
 
 plugin-install "$@"


### PR DESCRIPTION
Any install of a different plugin triggers the `plugin-install` hook, which caused the `stream` directive to be appended to `nginx.conf` multiple times.

This change makes the install step idempotent by checking for an existing
`include /etc/nginx/app-stream/*.conf` entry before appending the `stream` block.
The check is not perfect, regex-based, but sufficient to prevent duplicate `stream` blocks added by this plugin.